### PR TITLE
feat: localStorage in Taro

### DIFF
--- a/src/bom/index.ts
+++ b/src/bom/index.ts
@@ -1,4 +1,5 @@
 export * from './fetch'
 export * from './navigator'
 export * from './performance'
+export * from './storage'
 export * from './raf'

--- a/src/bom/storage.ts
+++ b/src/bom/storage.ts
@@ -51,7 +51,7 @@ export class TaroStorage implements Storage {
      */
     setItem(keyName: string, keyValue: string): void {
         try {
-            const value = String(keyValue)
+            const value = keyValue === 'string' ? keyValue : JSON.stringify(keyValue)
             Taro.setStorageSync(keyName, value)
         } catch (e) {
             // should throw a "QuotaExceededError" DOMException
@@ -114,7 +114,7 @@ class SessionStorage implements Storage {
      * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
      */
     setItem(keyName: string, keyValue: string): void {
-        const value = String(keyValue)
+        const value = keyValue === 'string' ? keyValue : JSON.stringify(keyValue)
         this.storage.set(keyName, value)
     }
 }

--- a/src/bom/storage.ts
+++ b/src/bom/storage.ts
@@ -33,7 +33,7 @@ export class TaroStorage implements Storage {
      */
     key(index: number): string | null {
         const { keys } = Taro.getStorageInfoSync()
-        if (index >= keys.length) return null
+        if (index >= keys.length || index < 0) return null
         return keys[index]
     }
 

--- a/src/bom/storage.ts
+++ b/src/bom/storage.ts
@@ -49,7 +49,7 @@ export class TaroStorage implements Storage {
      *
      * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
      */
-    setItem(keyName: string, keyValue: any): void {
+    setItem(keyName: string, keyValue: string): void {
         try {
             const value = String(keyValue)
             Taro.setStorageSync(keyName, value)
@@ -60,4 +60,64 @@ export class TaroStorage implements Storage {
     }
 }
 
-export const localStorage = new Storage()
+class SessionStorage implements Storage {
+    private storage: Map<string, string>
+
+    constructor() {
+        this.storage = new Map<string, string>()
+    }
+
+    /**
+     * Returns the number of key/value pairs currently present in the list associated with the object.
+     */
+    get length(): number {
+        return this.storage.size
+    }
+
+    /**
+     * Empties the list associated with the object of all key/value pairs, if there are any.
+     */
+    clear(): void {
+        this.storage.clear()
+    }
+
+    /**
+     * Returns the current value associated with the given key, or null if the given key does not exist in the list associated with the object.
+     */
+    getItem(keyName: string): string | null {
+        const value = this.storage.get(keyName)
+        if (!value) return null
+
+        if (typeof value === 'string') return value
+        return JSON.stringify(value)
+    }
+
+    /**
+     * Returns the name of the nth key in the list, or null if n is greater than or equal to the number of key/value pairs in the object.
+     */
+    key(index: number): string | null {
+        const keys = [...this.storage.keys()]
+        if (index >= keys.length || index < 0) return null
+        return keys[index]
+    }
+
+    /**
+     * Removes the key/value pair with the given key from the list associated with the object, if a key/value pair with the given key exists.
+     */
+    removeItem(keyName: string): void {
+        this.storage.delete(keyName)
+    }
+
+    /**
+     * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
+     *
+     * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
+     */
+    setItem(keyName: string, keyValue: string): void {
+        const value = String(keyValue)
+        this.storage.set(keyName, value)
+    }
+}
+
+export const localStorage = new TaroStorage()
+export const sessionStorage = new SessionStorage()

--- a/src/bom/storage.ts
+++ b/src/bom/storage.ts
@@ -1,0 +1,31 @@
+import Taro from '@tarojs/taro'
+
+export class Storage implements Storage {
+    get length(): number {
+        const { keys } = Taro.getStorageInfoSync()
+        return keys.length
+    }
+
+    clear(): any {
+        Taro.clearStorageSync()
+    }
+
+    getItem(keyName: string): any {
+        return Taro.getStorageSync(keyName)
+    }
+
+    key(index: number): string {
+        const { keys } = Taro.getStorageInfoSync()
+        return keys[index]
+    }
+
+    removeItem(keyName: string): void {
+        Taro.removeStorageSync(keyName)
+    }
+
+    setItem(keyName: string, keyValue: any): void {
+        Taro.setStorageSync(keyName, keyValue)
+    }
+}
+
+export const localStorage = new Storage()

--- a/src/bom/storage.ts
+++ b/src/bom/storage.ts
@@ -1,30 +1,62 @@
 import Taro from '@tarojs/taro'
 
-export class Storage implements Storage {
+export class TaroStorage implements Storage {
+    /**
+     * Returns the number of key/value pairs currently present in the list associated with the object.
+     */
     get length(): number {
         const { keys } = Taro.getStorageInfoSync()
         return keys.length
     }
 
-    clear(): any {
+    /**
+     * Empties the list associated with the object of all key/value pairs, if there are any.
+     */
+    clear(): void {
         Taro.clearStorageSync()
     }
 
-    getItem(keyName: string): any {
-        return Taro.getStorageSync(keyName)
+    /**
+     * Returns the current value associated with the given key, or null if the given key does not exist in the list associated with the object.
+     */
+    getItem(keyName: string): string | null {
+        const { keys } = Taro.getStorageInfoSync()
+        if (!keys.includes(keyName)) return null
+
+        const value = Taro.getStorageSync(keyName)
+        if (typeof value === 'string') return value
+        return value
     }
 
-    key(index: number): string {
+    /**
+     * Returns the name of the nth key in the list, or null if n is greater than or equal to the number of key/value pairs in the object.
+     */
+    key(index: number): string | null {
         const { keys } = Taro.getStorageInfoSync()
+        if (index >= keys.length) return null
         return keys[index]
     }
 
+    /**
+     * Removes the key/value pair with the given key from the list associated with the object, if a key/value pair with the given key exists.
+     */
     removeItem(keyName: string): void {
         Taro.removeStorageSync(keyName)
     }
 
+    /**
+     * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
+     *
+     * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
+     */
     setItem(keyName: string, keyValue: any): void {
-        Taro.setStorageSync(keyName, keyValue)
+        try {
+            const value = String(keyValue)
+            Taro.setStorageSync(keyName, value)
+        } catch (e) {
+            // should throw a "QuotaExceededError" DOMException
+            throw e
+        }
     }
 }
 

--- a/src/bom/storage.ts
+++ b/src/bom/storage.ts
@@ -25,7 +25,7 @@ export class TaroStorage implements Storage {
 
         const value = Taro.getStorageSync(keyName)
         if (typeof value === 'string') return value
-        return value
+        return JSON.stringify(value)
     }
 
     /**

--- a/src/plugins/TaroProvidePlugin.ts
+++ b/src/plugins/TaroProvidePlugin.ts
@@ -19,7 +19,7 @@ const cancelAnimationFrame = [`${prefix}/bom/raf`, 'caf']
 
 const Intl = ['intl']
 
-const Storage = [`${prefix}/bom/storage`, 'Storage']
+const Storage = [`${prefix}/bom/storage`, 'TaroStorage']
 const localStorage = [`${prefix}/bom/storage`, 'localStorage']
 
 let taroRuntimeVersion = '0.0.0'

--- a/src/plugins/TaroProvidePlugin.ts
+++ b/src/plugins/TaroProvidePlugin.ts
@@ -19,6 +19,9 @@ const cancelAnimationFrame = [`${prefix}/bom/raf`, 'caf']
 
 const Intl = ['intl']
 
+const Storage = [`${prefix}/bom/storage`, 'Storage']
+const localStorage = [`${prefix}/bom/storage`, 'localStorage']
+
 let taroRuntimeVersion = '0.0.0'
 try {
     const { version } = require(path.join(
@@ -45,7 +48,12 @@ export class TaroProvidePlugin extends ProvidePlugin {
     }
 
     static buildDefinitions(identifiers = ['default'] as TaroProvidePluginIdentifiers[]): Record<string, string[]> {
-        const defaultIdentifiers: TaroProvidePluginIdentifiers[] = ['fetch', 'performanceNow', 'requestAnimationFrame']
+        const defaultIdentifiers: TaroProvidePluginIdentifiers[] = [
+            'fetch',
+            'performanceNow',
+            'requestAnimationFrame',
+            'Storage',
+        ]
 
         // if (semver.lt(taroRuntimeVersion, '3.0.0-rc.1')) defaultIdentifiers.push('requestAnimationFrame')
         if (semver.lt(taroRuntimeVersion, '3.0.0-alpha.6')) defaultIdentifiers.push('navigator')
@@ -97,6 +105,15 @@ export class TaroProvidePlugin extends ProvidePlugin {
             return {
                 Intl,
                 ['window.Intl']: Intl,
+            }
+        },
+
+        get Storage() {
+            return {
+                Storage,
+                localStorage,
+                ['window.Storage']: Storage,
+                ['window.localStorage']: localStorage,
             }
         },
     }

--- a/src/plugins/TaroProvidePlugin.ts
+++ b/src/plugins/TaroProvidePlugin.ts
@@ -21,6 +21,7 @@ const Intl = ['intl']
 
 const Storage = [`${prefix}/bom/storage`, 'TaroStorage']
 const localStorage = [`${prefix}/bom/storage`, 'localStorage']
+const sessionStorage = [`${prefix}/bom/storage`, 'sessionStorage']
 
 let taroRuntimeVersion = '0.0.0'
 try {
@@ -114,6 +115,7 @@ export class TaroProvidePlugin extends ProvidePlugin {
                 localStorage,
                 ['window.Storage']: Storage,
                 ['window.localStorage']: localStorage,
+                ['window.sessionStorage']: sessionStorage,
             }
         },
     }


### PR DESCRIPTION
为 Taro 增加 [`Storage`](https://developer.mozilla.org/en-US/docs/Web/API/Storage) polyfill。


### QUESTION

- 浏览器中的 localStorage 效果是存储并返回 string，但是小程序中可以存储任意基本类型和 Object。实践中当然后者更友好，但是否应该为了抹平 API 差异，将内容转换成 string 进行存储？或者暴露出配置接口，由开发者自己决定？
- 这个 API 实现更像是 [tarojsx/history](https://github.com/tarojsx/history)，是否要单独拿出来做一个库？

### TODO

- [x] [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
- [x] [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
- [ ] ~~[StorageEvent](https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent)~~